### PR TITLE
Simplified the Make.bat (Windows) and added User Prompt

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -62,26 +62,21 @@ git log --oneline --decorate > CHANGELOG
 echo Changelog Build Finished
 echo.
 
-
-  for /F "tokens=2 delims==" %%s in ('set ARCH[') do (
  
 
     SET GOOS=windows
-    SET GOARCH=%%s
-    SET GOARM=6
-    echo Building !GOOS!/!GOARCH!
+    echo Building !GOOS!
 
     SET EXTENSION=".exe"
 	IF "%1" == "all" (
-      	go build -buildmode=exe -ldflags "-s -w -X main.version=%@version% -X main.buildstamp=%@bdate%-%@btime% -X main.hash=%@gitrev%" -o bin/atomic-harness_!GOARCH!!EXTENSION! ./cmd/harness/
-      	go build -buildmode=exe -ldflags "-s -w -X main.version=%@version% -X main.buildstamp=%@bdate%-%@btime% -X main.hash=%@gitrev%" -o bin/atrutil_!GOARCH!!EXTENSION! ./cmd/atrutil
+      	go build -buildmode=exe -ldflags "-s -w -X main.version=%@version% -X main.buildstamp=%@bdate%-%@btime% -X main.hash=%@gitrev%" -o bin/atomic-harness!EXTENSION! ./cmd/harness/
+      	go build -buildmode=exe -ldflags "-s -w -X main.version=%@version% -X main.buildstamp=%@bdate%-%@btime% -X main.hash=%@gitrev%" -o bin/atrutil!EXTENSION! ./cmd/atrutil
    	)
  	IF "%1" == "atrutil" (
-      	go build -buildmode=exe -ldflags "-s -w -X main.version=%@version% -X main.buildstamp=%@bdate%-%@btime% -X main.hash=%@gitrev%" -o bin/atrutil_!GOARCH!!EXTENSION! ./cmd/atrutil
+      	go build -buildmode=exe -ldflags "-s -w -X main.version=%@version% -X main.buildstamp=%@bdate%-%@btime% -X main.hash=%@gitrev%" -o bin/atrutil!EXTENSION! ./cmd/atrutil
    	)
 	IF "%1" == "atomic-harness" (
-      	go build -buildmode=exe -ldflags "-s -w -X main.version=%@version% -X main.buildstamp=%@bdate%-%@btime% -X main.hash=%@gitrev%" -o bin/atomic-harness_!GOARCH!!EXTENSION! ./cmd/harness/
+      	go build -buildmode=exe -ldflags "-s -w -X main.version=%@version% -X main.buildstamp=%@bdate%-%@btime% -X main.hash=%@gitrev%" -o bin/atomic-harness!EXTENSION! ./cmd/harness/
    	)
-   )
 )
-echo Finished Building
+echo Finished Building. Executables located in /bin directory

--- a/make.bat
+++ b/make.bat
@@ -79,4 +79,4 @@ echo.
       	go build -buildmode=exe -ldflags "-s -w -X main.version=%@version% -X main.buildstamp=%@bdate%-%@btime% -X main.hash=%@gitrev%" -o bin/atomic-harness!EXTENSION! ./cmd/harness/
    	)
 )
-echo Finished Building. Executables located in /bin directory
+echo Finished Building. Executables located in ./bin directory


### PR DESCRIPTION
-  Turns out you only need to build Go to a certain architecture if you plan on shipping executables; if the source code is available (as it is in this case), this works better.
- Added a prompt after build which tells user where the executables are located for ease of user and better user experience