### PR TITLE
Add missing newline

### DIFF
--- a/cmd/atrutil/atrutil_main.go
+++ b/cmd/atrutil/atrutil_main.go
@@ -547,7 +547,7 @@ func GenerateCriteria(tid string) error {
 
 				if !gUnsafe {
 					if unsafeRegex.MatchString(com) {
-						s += "!!!, Potentially destructive command found: " + com
+						s += fmt.Sprintln("!!!, Potentially destructive command found:", com)
 					}
 				}
 


### PR DESCRIPTION
gencriteria adds warning for potentially destructive delete, but no newline before the `_E_` line