### PR TITLE
filepath fix for windows

### DIFF
--- a/cmd/goartrun/executor.go
+++ b/cmd/goartrun/executor.go
@@ -358,11 +358,16 @@ func interpolateWithArgs(interpolatee, base string, args map[string]string, quie
 
 		if AtomicsFolderRegex.MatchString(v) {
 			v = AtomicsFolderRegex.ReplaceAllString(v, "")
-			v = strings.ReplaceAll(v, `\`, `/`)
-			v = strings.TrimSuffix(base, "/") + "/" + v
+			if runtime.GOOS != "windows" {
+				v = strings.ReplaceAll(v, `\`, `/`)
+				v = strings.TrimSuffix(base, "/") + "/" + v
+			} else {
+				v = strings.TrimSuffix(base, "\\") + "\\" + v
+			}
 		}
 
 		interpolated = strings.ReplaceAll(interpolated, "#{"+k+"}", v)
+
 	}
 
 	return interpolated, nil


### PR DESCRIPTION
Windows uses '\\' instead of '/'  in filepaths. So added an if condition to tackle this issue. 
FYI @kdebscwx 