### PR TITLE
Inclusion of hashes field for process events

### DIFF
--- a/cmd/harness/validate.go
+++ b/cmd/harness/validate.go
@@ -100,6 +100,8 @@ func CheckProcessEvent(testRun *SingleTestRun, evt *types.SimpleEvent, nativeJso
 				isMatch = CheckMatch(evt.ProcessFields.Env, fc.Op, fc.Value)
 			case "is_elevated":
 				isMatch = CheckMatch(BoolAsString(evt.ProcessFields.IsElevated), fc.Op, fc.Value)
+			case "hashes":
+				isMatch = CheckMatch(evt.ProcessFields.Hashes, fc.Op, fc.Value)
 			default:
 				fmt.Println("ERROR: unknown FieldName", fc)
 			}

--- a/pkg/types/harness_simple_telemetry.go
+++ b/pkg/types/harness_simple_telemetry.go
@@ -34,6 +34,7 @@ type SimpleProcessFields struct {
 	ExePath    string `json:"exe_path,omitempty"`
 	Env        string `json:"env,omitempty"`
 	IsElevated bool   `json:"is_elevated,omitempty"`
+	Hashes     string `json:"hashes,omitempty"`
 
 	UniquePid       string `json:"unique_pid",omitempty`
 	ParentUniquePid string `json:"parent_unique_pid,omitempty"`


### PR DESCRIPTION
Included the hashes field in the process event function so that it allows to verify the hashes between two executable files. 
FYI @kdebscwx  