### PR TITLE
Not equal operator

### DIFF
--- a/cmd/harness/validate.go
+++ b/cmd/harness/validate.go
@@ -51,6 +51,8 @@ func CheckMatch(haystack, op, needle string) bool {
 			return false
 		}
 		return rx.MatchString(haystack)
+	case "!=":
+		return haystack != needle
 	default:
 		fmt.Println("ERROR: unsupported operator", op)
 	}

--- a/pkg/utils/datafile.go
+++ b/pkg/utils/datafile.go
@@ -62,6 +62,9 @@ func ParseFieldCriteria(str string, eventType string) (*types.FieldCriteria, err
 	case '~':
 		fc.Op = "~="
 		namelen -= 1
+	case '!':
+		fc.Op = "!="
+		namelen -= 1
 	default:
 		fc.Op = "="
 	}


### PR DESCRIPTION
Addition of new validation operator: Not equal, which gets validated when the field_name is not equal to the given value. The use case of this operator comes when we are trying to find if an executable file is masquerading as another executable.
FYI @kdebscwx  