### PR TITLE
Setting the value of ErrorActionPreference variable as "Stop"

### DIFF
--- a/cmd/goartrun/executor.go
+++ b/cmd/goartrun/executor.go
@@ -462,6 +462,7 @@ func executeCMD(shellName string, command string, env []string, stage string, te
 }
 
 func executePS(shellName string, command string, env []string, stage string, technique string, testName string, runSpec *types.RunSpec, timeout int) (string, error) {
+	command = "$ErrorActionPreference = \"Stop\"\n" + command // If a command fails then subsequent commands will not be executed
 	fmt.Printf("\nExecuting executor=%s command=[%s]\n", shellName, command)
 
 	f, err := os.Create(runSpec.TempDir + "\\goart-" + technique + "-" + stage + ".ps1")


### PR DESCRIPTION
The default value of _ErrorActionPreference_ variable in PowerShell is "continue". Due to this when we run a set of commands in the framework if one command fails, it still runs the rest of them and shows "TestRan". To solve this issue we are setting this variable to "Stop" value so that if one command fails then subsequent commands are not executed and the framework displays "TestFail".
FYI @kdebscwx 