### PR TITLE
Refactor and simplify goartrun

### DIFF
--- a/cmd/goartrun/README.md
+++ b/cmd/goartrun/README.md
@@ -1,19 +1,46 @@
 # goartrun
 
-## Goals
+## Summary
 
-This is now exclusively for use by the atomic-harness.  However, it is still possible to use run this directly to debug the `prereq,checkreq,test,cleanup` stages of an atomic red team test directly.
+This is a script runner exclusively used by the atomic-harness.
 
-## Beginnings
+- Dropping of Elevated Privileges - While harness should be run as root, tests can be run as regular users.
+- Handles the platform specific script types (sh,bash,powershell,cmd)
+- Timeout - will kill a script command if taking too long
 
-This began as a hard fork of MIT-licensed https://github.com/activeshadow/go-atomicredteam .
-My goals are automation and security.  I stripped away all non essential packages and non-github imports like `"actshad.dev/go-atomicredteam"`
+## Input Schema
 
-## Initial Run Design
-The goal is to make this runner pull config from input file or stdin JSON rather than commandline arguments.
-```sh
-bin/goart --atomicsdir $HOME/atomic-red-team/atomics \
-          --tempdir /tmp/goart-xyz333 \
-          -t T1571 -i 1 \          # Invoke-Atomic uses 1-based, this uses 0-based indexes
-          domain=172.20.10.15      # test arguments
+[runspec.go](../../pkg/types/runspec.go) contains the definitions for the input config object `RunSpec` .  The harness will provide the `RunSpec` in JSON format `--config` argument as a path or `-` for stdin.
+
+```go
+type RunSpec struct {
+    ID              string          // e.g. T1059.002 #7 67e5d354
+    Label           string          // e.g. AppleScript NSAppleScript execution
+
+    TempDir    string
+    ResultsDir string
+    Username   string               // if not root, value of SUDO_USER
+
+    EnvOverrides map[string]string
+    Script       *AtomicExecutor    // test script
+
+    DependencyExecutorName string   // e.g. sh, bash, powershell, cmd
+    Dependencies []Dependency       // optional dependency checks
+
+    Stage   string
+    Timeout int64
+}
+```
+
+## Output Results Schema
+
+```go
+type ScriptResults struct {
+        Spec RunSpec
+
+        Status      int
+        IsCleanedUp bool
+        StartTime   int64
+        EndTime     int64
+}
 ```

--- a/cmd/goartrun/executor.go
+++ b/cmd/goartrun/executor.go
@@ -5,100 +5,83 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
-	"strings"
 	"time"
 
 	types "github.com/secureworks/atomic-harness/pkg/types"
-	utils "github.com/secureworks/atomic-harness/pkg/utils"
 )
 
 var SupportedExecutors = []string{"bash", "sh", "command_prompt", "powershell"}
 
-func Execute(test *types.AtomicTest, runSpec *types.RunSpec, timeout int) (*types.AtomicTest, error, types.TestStatus) {
-	tid := runSpec.Technique
-	env := []string{} // TODO
+func Execute(runSpec *types.RunSpec, timeout int) (*types.ScriptResults, error, types.TestStatus) {
+    retval := &types.ScriptResults{}
+    retval.Spec = *runSpec
 
 	fmt.Println()
 
 	fmt.Println("****** EXECUTION PLAN ******")
-	fmt.Println(" Technique: " + tid)
-	fmt.Println(" Test:      " + test.Name)
+	fmt.Println(" ", runSpec.Label)
 
 	stage := runSpec.Stage
 	if stage != "" {
 		fmt.Println(" Stage:     " + stage)
 	}
 
-	if len(runSpec.Inputs) == 0 {
-		fmt.Println(" Inputs:    <none>")
-	} else {
-		fmt.Println(" Inputs:    ", runSpec.Inputs)
-	}
-	/*
-		if env == nil {
-			fmt.Println(" Env:       <none>")
-		} else {
-			fmt.Println(" Env:       " + strings.Join(env, "\n            "))
-		}
-	*/
-	fmt.Println(" * Use at your own risk :) *")
-	fmt.Println("****************************")
-
-	args, err := checkArgsAndGetDefaults(test, runSpec)
-	if err != nil {
-		return nil, err, types.StatusInvalidArguments
-	}
-
-	// overwrite with actual args used
-	test.ArgsUsed = args
-
-	if err := checkPlatform(test); err != nil {
-		return nil, err, types.StatusInvalidArguments
-	}
-
-	//var results string
-
 	stages := []string{"prereq", "test", "cleanup"}
 	if "" != stage {
 		stages = []string{stage}
 	}
 
+    if 0 == len(runSpec.Script.Name) {
+        if "windows" == runtime.GOOS {
+                fmt.Println("no executor specified. Using powershell")
+                runSpec.Script.Name = "powershell"
+        } else {
+                fmt.Println("no executor specified. Using sh")
+                runSpec.Script.Name = "sh"
+        }
+    }
+
+    for name,val := range runSpec.EnvOverrides {
+        fmt.Println("ENV override", name)
+        os.Setenv(name, val)
+    }
+
+    var err error
 	status := types.StatusUnknown
 	for _, stage = range stages {
 		switch stage {
 		case "cleanup":
-			_, err = executeStage(stage, test.Executor.CleanupCommand, test.Executor.Name, test.BaseDir, args, env, tid, test.Name, runSpec, timeout)
+			_, err = executeStage(stage, runSpec.Script.Name, runSpec.Script.CleanupCommand, runSpec.ID, runSpec.Label, runSpec, timeout)
 			if err != nil {
 				fmt.Println("WARNING. Cleanup command failed", err)
 			} else {
-				test.IsCleanedUp = true
+				retval.IsCleanedUp = true
 			}
 
 		case "prereq":
-			if len(test.Dependencies) != 0 {
-				executorName := test.DependencyExecutorName
+			if len(runSpec.Dependencies) != 0 {
+				executorName := runSpec.DependencyExecutorName
 				if len(executorName) == 0 {
-					executorName = test.Executor.Name
+					executorName = runSpec.Script.Name
 				}
 				if IsUnsupportedExecutor(executorName) {
-					return nil, fmt.Errorf("dependency executor %s (%s) is not supported", test.DependencyExecutorName, test.Executor.Name), types.StatusInvalidArguments
+					return nil, fmt.Errorf("dependency executor %s (%s) is not supported", runSpec.DependencyExecutorName, runSpec.Script.Name), types.StatusInvalidArguments
 				}
 
 				fmt.Printf("\nChecking dependencies...\n")
 
-				for i, dep := range test.Dependencies {
+				for i, dep := range runSpec.Dependencies {
 					fmt.Printf("  - %s", dep.Description)
 
-					_, err := executeStage(fmt.Sprintf("checkPrereq%d", i), dep.PrereqCommand, executorName, test.BaseDir, args, env, tid, test.Name, runSpec, timeout)
+					_, err := executeStage(fmt.Sprintf("checkPrereq%d", i), runSpec.Script.Name, dep.PrereqCommand, runSpec.ID, runSpec.Label, runSpec, timeout)
 
 					if err == nil {
 						fmt.Printf("   * OK - dependency check succeeded!\n")
 						continue
 					}
 
-					result, err := executeStage(fmt.Sprintf("getPrereq%d", i), dep.GetPrereqCommand, executorName, test.BaseDir, args, env, tid, test.Name, runSpec, timeout)
+					result, err := executeStage(fmt.Sprintf("getPrereq%d", i), runSpec.Script.Name, dep.GetPrereqCommand, runSpec.ID, runSpec.Label, runSpec, timeout)
 
 					if err != nil {
 						if result == "" {
@@ -112,18 +95,18 @@ func Execute(test *types.AtomicTest, runSpec *types.RunSpec, timeout int) (*type
 				}
 			}
 		case "test":
-			if test.Executor == nil {
+			if runSpec.Script == nil {
 				return nil, fmt.Errorf("test has no executor"), types.StatusInvalidArguments
 			}
 
-			if IsUnsupportedExecutor(test.Executor.Name) {
-				return nil, fmt.Errorf("executor %s is not supported", test.Executor.Name), types.StatusInvalidArguments
+			if IsUnsupportedExecutor(runSpec.Script.Name) {
+				return nil, fmt.Errorf("executor %s is not supported", runSpec.Script.Name), types.StatusInvalidArguments
 			}
-			test.StartTime = time.Now().UnixNano()
+			retval.StartTime = time.Now().UnixNano()
 
-			results, err := executeStage(stage, test.Executor.Command, test.Executor.Name, test.BaseDir, args, env, tid, test.Name, runSpec, timeout)
+			results, err := executeStage(stage, runSpec.Script.Name, runSpec.Script.Command, runSpec.ID, runSpec.Label, runSpec, timeout)
 
-			test.EndTime = time.Now().UnixNano()
+			retval.EndTime = time.Now().UnixNano()
 
 			errstr := ""
 			if err != nil {
@@ -141,23 +124,15 @@ func Execute(test *types.AtomicTest, runSpec *types.RunSpec, timeout int) (*type
 
 			// save state
 
-			for k, v := range test.InputArugments {
-				v.ExpectedValue = args[k]
-				test.InputArugments[k] = v
-			}
-
-			test.Executor.ExecutedCommand = map[string]interface{}{
-				"command": test.Executor.Command, /* command */
-				"results": results,
-				"err":     errstr,
-			}
+			retval.CommandStdout = results
+			retval.ErrorMsg = errstr
 
 		default:
 			fmt.Printf("Unknown stage:" + stage)
 			return nil, nil, types.StatusRunnerFailure
 		}
 	}
-	return test, nil, status
+	return retval, nil, status
 
 }
 
@@ -170,138 +145,10 @@ func IsUnsupportedExecutor(executorName string) bool {
 	return true
 }
 
-func getTest(tid, name string, index int, runSpec *types.RunSpec) (*types.AtomicTest, error) {
-	fmt.Printf("\nGetting Atomic Tests technique %s from %s\n", tid, runSpec.AtomicsDir)
-
-	technique, err := utils.LoadAtomicsTechniqueYaml(tid, runSpec.AtomicsDir)
-	if err != nil {
-		return nil, fmt.Errorf("getting Atomic Tests technique: %w", err)
-	}
-
-	fmt.Printf("  - technique has %d tests\n", len(technique.AtomicTests))
-
-	var test *types.AtomicTest
-
-	if index >= 0 && index < len(technique.AtomicTests) {
-		test = &technique.AtomicTests[index]
-	} else {
-		for _, t := range technique.AtomicTests {
-			if t.Name == name {
-				test = &t
-				break
-			}
-		}
-	}
-
-	if test == nil {
-		return nil, fmt.Errorf("could not find test %s/%s", tid, name)
-	}
-
-	test.BaseDir = technique.BaseDir
-	test.TempDir = runSpec.TempDir
-
-	fmt.Printf("  - found test named %s\n", test.Name)
-
-	return test, nil
-}
-
-func checkArgsAndGetDefaults(test *types.AtomicTest, runSpec *types.RunSpec) (map[string]string, error) {
-	var (
-		updated = make(map[string]string)
-	)
-
-	if len(test.InputArugments) == 0 {
-		return updated, nil
-	}
-
-	keys := []string{}
-	for k := range runSpec.Inputs {
-		keys = append(keys, k)
-	}
-
-	fmt.Println("\nChecking arguments...")
-
-	if len(keys) > 0 {
-		fmt.Println("  - supplied in config/flags: " + strings.Join(keys, ", "))
-	}
-
-	for k, v := range test.InputArugments {
-		fmt.Println("  - checking for argument " + k)
-
-		val, ok := runSpec.Inputs[k] //args[k]
-
-		if ok {
-			fmt.Println("   * OK - found argument in supplied args")
-		} else {
-			fmt.Println("   * XX - not found, trying default arg")
-
-			val = v.Default
-
-			if val == "" {
-				return nil, fmt.Errorf("argument [%s] is required but not set and has no default", k)
-			} else {
-				fmt.Println("   * OK - found argument in defaults")
-			}
-		}
-
-		updated[k] = val
-	}
-
-	return updated, nil
-}
-
-func checkPlatform(test *types.AtomicTest) error {
-	var platform string
-
-	switch runtime.GOOS {
-	case "linux", "freebsd", "netbsd", "openbsd", "solaris":
-		platform = "linux"
-	case "darwin":
-		platform = "macos"
-	case "windows":
-		platform = "windows"
-	}
-
-	if platform == "" {
-		return fmt.Errorf("unable to detect our platform")
-	}
-
-	fmt.Printf("\nChecking platform vs our platform (%s)...\n", platform)
-
-	var found bool
-
-	for _, p := range test.SupportedPlatforms {
-		if p == platform {
-			found = true
-			break
-		}
-	}
-
-	if found {
-		fmt.Println("  - OK - our platform is supported!")
-	} else {
-		return fmt.Errorf("unable to run test that supports platforms %v because we are on %s", test.SupportedPlatforms, platform)
-	}
-
-	return nil
-}
-
-func executeStage(stage, cmds, executorName, base string, args map[string]string, env []string, technique, testName string, runSpec *types.RunSpec, timeout int) (string, error) {
-	quiet := true
-
-	if stage == "test" {
-		quiet = false
-	}
-
-	if cmds == "" {
+func executeStage(stage, executorName, command string, technique, testName string, runSpec *types.RunSpec, timeout int) (string, error) {
+	if command == "" {
 		fmt.Println("Test does not have " + stage + " stage defined")
 		return "", nil
-	}
-
-	command, err := interpolateWithArgs(cmds, base, args, quiet)
-	if err != nil {
-		fmt.Println("    * FAIL - "+stage+" failed", err)
-		return "", err
 	}
 
 	if 0 == len(executorName) {
@@ -315,15 +162,16 @@ func executeStage(stage, cmds, executorName, base string, args map[string]string
 	}
 
 	var results string
+	var err error
 	switch executorName {
 	case "bash":
-		results, err = executeShell("bash", command, env, stage, technique, testName, runSpec, timeout)
+		results, err = executeShell("bash", command, stage, technique, testName, runSpec, timeout)
 	case "sh":
-		results, err = executeShell("sh", command, env, stage, technique, testName, runSpec, timeout)
+		results, err = executeShell("sh", command, stage, technique, testName, runSpec, timeout)
 	case "command_prompt":
-		results, err = executeCMD("CMD", command, env, stage, technique, testName, runSpec, timeout)
+		results, err = executeCMD("CMD", command, stage, technique, testName, runSpec, timeout)
 	case "powershell":
-		results, err = executePS("POWERSHELL", command, env, stage, technique, testName, runSpec, timeout)
+		results, err = executePS("POWERSHELL", command, stage, technique, testName, runSpec, timeout)
 	default:
 		err = fmt.Errorf("unknown executor: " + executorName)
 	}
@@ -336,42 +184,7 @@ func executeStage(stage, cmds, executorName, base string, args map[string]string
 	return results, nil
 }
 
-func interpolateWithArgs(interpolatee, base string, args map[string]string, quiet bool) (string, error) {
-	interpolated := strings.TrimSpace(interpolatee)
-
-	// replace folder path if present in script
-
-	interpolated = strings.ReplaceAll(interpolated, "$PathToAtomicsFolder", base)
-	interpolated = strings.ReplaceAll(interpolated, "PathToAtomicsFolder", base)
-
-	if len(args) == 0 {
-		return interpolated, nil
-	}
-
-	if !quiet {
-		fmt.Println("\nInterpolating command with input arguments...")
-	}
-
-	for k, v := range args {
-		if !quiet {
-			fmt.Printf("  - interpolating [#{%s}] => [%s]\n", k, v)
-		}
-		if !strings.HasPrefix(v, "http") { // No modification of slashes in case of URLs
-			if AtomicsFolderRegex.MatchString(v) {
-				v = AtomicsFolderRegex.ReplaceAllString(v, "")
-				v = strings.ReplaceAll(v, `\`, `/`)
-				v = strings.TrimSuffix(base, "/") + "/" + v
-			}
-
-			v = filepath.FromSlash(v)
-		}
-		interpolated = strings.ReplaceAll(interpolated, "#{"+k+"}", v)
-	}
-
-	return interpolated, nil
-}
-
-func executeShell(shellName string, command string, env []string, stage string, technique string, testName string, runSpec *types.RunSpec, timeout int) (string, error) {
+func executeShell(shellName string, command string, stage string, technique string, testName string, runSpec *types.RunSpec, timeout int) (string, error) {
 	fmt.Printf("\nExecuting executor=%s command=[%s]\n", shellName, command)
 
 	f, err := os.Create(runSpec.TempDir + "/goart-" + technique + "-" + stage + "." + shellName)
@@ -398,7 +211,7 @@ func executeShell(shellName string, command string, env []string, stage string, 
 
 	cmd := exec.CommandContext(ctx, shellName, f.Name())
 
-	cmd.Env = append(os.Environ(), env...)
+	//cmd.Env = append(os.Environ(), env...)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -421,7 +234,7 @@ func executeShell(shellName string, command string, env []string, stage string, 
 	return string(output), nil
 }
 
-func executeCMD(shellName string, command string, env []string, stage string, technique string, testName string, runSpec *types.RunSpec, timeout int) (string, error) {
+func executeCMD(shellName string, command string, stage string, technique string, testName string, runSpec *types.RunSpec, timeout int) (string, error) {
 	fmt.Printf("\nExecuting executor=%s command=[%s]\n", shellName, command)
 
 	f, err := os.Create(runSpec.TempDir + "\\goart-" + technique + "-" + stage + ".bat")
@@ -448,8 +261,6 @@ func executeCMD(shellName string, command string, env []string, stage string, te
 
 	cmd := exec.CommandContext(ctx, shellName, "/c", f.Name())
 
-	cmd.Env = append(os.Environ(), env...)
-
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if context.DeadlineExceeded == ctx.Err() {
@@ -461,7 +272,7 @@ func executeCMD(shellName string, command string, env []string, stage string, te
 	return string(output), nil
 }
 
-func executePS(shellName string, command string, env []string, stage string, technique string, testName string, runSpec *types.RunSpec, timeout int) (string, error) {
+func executePS(shellName string, command string, stage string, technique string, testName string, runSpec *types.RunSpec, timeout int) (string, error) {
 	command = "$ErrorActionPreference = \"Stop\"\n" + command // If a command fails then subsequent commands will not be executed
 	fmt.Printf("\nExecuting executor=%s command=[%s]\n", shellName, command)
 
@@ -488,8 +299,6 @@ func executePS(shellName string, command string, env []string, stage string, tec
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, shellName, "-ExecutionPolicy", "Bypass", "-NoProfile", f.Name())
-
-	cmd.Env = append(os.Environ(), env...)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/cmd/goartrun/executor.go
+++ b/cmd/goartrun/executor.go
@@ -74,14 +74,14 @@ func Execute(runSpec *types.RunSpec, timeout int) (*types.ScriptResults, error, 
 				for i, dep := range runSpec.Dependencies {
 					fmt.Printf("  - %s", dep.Description)
 
-					_, err := executeStage(fmt.Sprintf("checkPrereq%d", i), runSpec.Script.Name, dep.PrereqCommand, runSpec.ID, runSpec.Label, runSpec, timeout)
+					_, err := executeStage(fmt.Sprintf("checkPrereq%d", i), executorName, dep.PrereqCommand, runSpec.ID, runSpec.Label, runSpec, timeout)
 
 					if err == nil {
 						fmt.Printf("   * OK - dependency check succeeded!\n")
 						continue
 					}
 
-					result, err := executeStage(fmt.Sprintf("getPrereq%d", i), runSpec.Script.Name, dep.GetPrereqCommand, runSpec.ID, runSpec.Label, runSpec, timeout)
+					result, err := executeStage(fmt.Sprintf("getPrereq%d", i), executorName, dep.GetPrereqCommand, runSpec.ID, runSpec.Label, runSpec, timeout)
 
 					if err != nil {
 						if result == "" {

--- a/cmd/goartrun/unix_utils.go
+++ b/cmd/goartrun/unix_utils.go
@@ -12,7 +12,7 @@ import (
 	types "github.com/secureworks/atomic-harness/pkg/types"
 )
 
-func ManagePrivilege(atomicTest *types.AtomicTest, runSpec *types.RunSpec) {
+func ManagePrivilege(runSpec *types.RunSpec) {
 	usr,err := user.Current()
 	if err != nil {
 		fmt.Println("ERROR: unable to determine current user", err)
@@ -20,7 +20,7 @@ func ManagePrivilege(atomicTest *types.AtomicTest, runSpec *types.RunSpec) {
 	}
 	if usr.Uid == "0" {
 		// we are running as root
-		if atomicTest.Executor.ElevationRequired {
+		if runSpec.Script.ElevationRequired {
 			fmt.Println("test requires Elevated privilege, remaining as root")
 			return
 		}
@@ -67,7 +67,7 @@ func ManagePrivilege(atomicTest *types.AtomicTest, runSpec *types.RunSpec) {
 	}
 
 	// we are normal user
-	if atomicTest.Executor.ElevationRequired {
+	if runSpec.Script.ElevationRequired {
 		fmt.Println("WARN: test requires Elevated privilege, but running as user",usr)
 		return
 	}

--- a/cmd/goartrun/version.go
+++ b/cmd/goartrun/version.go
@@ -1,3 +1,0 @@
-package main
-
-var Version = "version not set"

--- a/cmd/goartrun/windows_utils.go
+++ b/cmd/goartrun/windows_utils.go
@@ -6,6 +6,6 @@ import (
    types "github.com/secureworks/atomic-harness/pkg/types"
 )
 
-func ManagePrivilege(atomicTest *types.AtomicTest, runSpec *types.RunSpec) {
+func ManagePrivilege(runSpec *types.RunSpec) {
    // TODO: implement windows equivalent
 }

--- a/cmd/harness/main.go
+++ b/cmd/harness/main.go
@@ -20,6 +20,7 @@ import (
 	"syscall"
 	"time"
 
+	"gopkg.in/yaml.v3"
 	types "github.com/secureworks/atomic-harness/pkg/types"
 	utils "github.com/secureworks/atomic-harness/pkg/utils"
 )
@@ -51,6 +52,8 @@ type TelemTool struct {
 	Path   string // /some/path/to/telemtool_e2e.exe
 	Suffix string // _e2e
 }
+
+var AtomicsFolderRegex = regexp.MustCompile(`PathToAtomicsFolder(\\|\/)`)
 
 var kTestRunTimeoutSeconds = 10 * time.Second
 var kWaitTelemetrySeconds = 35
@@ -580,14 +583,14 @@ func UpdateTimestampsFromRunSummary(testRun *SingleTestRun) {
 		}
 		return
 	}
-	runSpec := &types.AtomicTest{}
-	if err = json.Unmarshal(data, runSpec); err != nil {
+	results := &types.ScriptResults{}
+	if err = json.Unmarshal(data, results); err != nil {
 		fmt.Println("Error parsing run_summary.json", path, err)
 		return
 	}
 
-	testRun.StartTime = runSpec.StartTime
-	testRun.EndTime = runSpec.EndTime
+	testRun.StartTime = results.StartTime
+	testRun.EndTime = results.EndTime
 }
 
 // echo runSpecJson | ./bin/goart --config -
@@ -721,15 +724,15 @@ ResultsDir string
 
 Inputs     map[string]string
 */
-func BuildRunSpec(spec *types.AtomicTestCriteria, atomicTempDir string, resultsDir string) string {
+func BuildRunSpec(atomic *types.AtomicTest, TestIndex int, spec *types.AtomicTestCriteria, atomicTempDir string, resultsDir string) string {
 	obj := types.RunSpec{}
-	obj.Technique = spec.Technique
-	obj.TestGuid = spec.TestGuid
-	obj.TestIndex = int(spec.TestIndex - 1)
+	obj.ID = fmt.Sprintf("%s #%d", spec.Technique, TestIndex+1)
+	obj.Label = spec.TestName
 	obj.TempDir = filepath.FromSlash(atomicTempDir)
-	obj.AtomicsDir, _ = filepath.Abs(filepath.FromSlash(flagAtomicsPath))
 	obj.ResultsDir, _ = filepath.Abs(filepath.FromSlash(resultsDir))
-	obj.Inputs = spec.Args
+	obj.Script = atomic.Executor
+	obj.Dependencies = atomic.Dependencies
+	// TODO: environment variable overrides?
 	obj.Username = flagRegularRunUser
 	obj.Timeout = flagTimeout
 	os.Mkdir(obj.ResultsDir, 0777)
@@ -1025,6 +1028,148 @@ func LoadTechniquesList(filename string) error {
 	return nil
 }
 
+
+func checkPlatform(test *types.AtomicTest) error {
+	var platform string
+
+	switch runtime.GOOS {
+	case "linux", "freebsd", "netbsd", "openbsd", "solaris":
+		platform = "linux"
+	case "darwin":
+		platform = "macos"
+	case "windows":
+		platform = "windows"
+	}
+
+	if platform == "" {
+		return fmt.Errorf("unable to detect our platform")
+	}
+
+	if gVerbose {
+		fmt.Println("platform:",platform, "test:", test.SupportedPlatforms)
+	}
+
+	for _, p := range test.SupportedPlatforms {
+		if p == platform {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("unable to run test that supports platforms %v because we are on %s", test.SupportedPlatforms, platform)
+}
+
+func LoadAtomic(Technique string, TestIndex uint, TestGuid, flagAtomicsPath string, isVerbose bool) (*types.AtomicTest,int) {
+	var body []byte
+
+	// Check to see if test is defined locally first. If not, body will be nil
+	// and the test will be loaded below.
+	atomicsPath, _ := filepath.Abs(flagAtomicsPath)
+	path := atomicsPath + "/" + Technique + "/" + Technique + ".yaml"
+	if isVerbose {
+		fmt.Println("loading", path)
+	}
+	body, _ = os.ReadFile(path)
+	if len(body) == 0 {
+		path = strings.ReplaceAll(path, ".yaml", ".yml")
+		fmt.Println("loading", path)
+		body, _ = os.ReadFile(path)
+	}
+
+	if len(body) == 0 {
+		fmt.Println("Failed to load atomic for ", Technique)
+		return nil,0
+	}
+
+	var atoms types.Atomic
+
+	if err := yaml.Unmarshal(body, &atoms); err != nil {
+		fmt.Println("processing Atomic Test YAML file", err)
+		return nil,0
+	}
+
+	for i, testInfo := range atoms.AtomicTests {
+		if TestIndex > 0 {
+			if (TestIndex - 1) != uint(i) {
+				continue
+			}
+		} else if len(TestGuid) > 0 {
+			if !strings.HasPrefix(testInfo.GUID, TestGuid) {
+				continue
+			}
+		} else {
+			fmt.Println("Criteria missing TestNum or TestGuid", Technique, TestIndex, TestGuid)
+			return nil,0
+		}
+		return &testInfo, i
+	}
+	return nil,0
+}
+
+func FillArgDefaults(atomicTest *types.AtomicTest, criteria *types.AtomicTestCriteria, atomicsPath string) {
+	for name, obj := range atomicTest.InputArugments {
+		_, ok := criteria.Args[name]
+		if ok {
+			continue // we have override value
+		}
+		if gVerbose {
+			fmt.Printf("  Loading default arg %s:'%s'\n", name, obj.Default)
+		}
+
+		val := strings.ReplaceAll(obj.Default, "$PathToAtomicsFolder", atomicsPath)
+		val = strings.ReplaceAll(val, "PathToAtomicsFolder", atomicsPath)
+
+		criteria.Args[name] = val
+	}
+}
+
+func consolidateArgs(atomic *types.AtomicTest, criteria *types.AtomicTestCriteria) map[string]string {
+	args := map[string]string{}
+	// get test defaults
+	for key,entry := range atomic.InputArugments {
+		args[key] = entry.Default
+	}
+	// override with criteria args
+	for key,val := range criteria.Args {
+		args[key] = val
+	}
+	return args
+}
+
+func interpolateWithArgs(interpolatee string, atomic *types.AtomicTest, args map[string]string) string {
+	interpolated := strings.TrimSpace(interpolatee)
+
+	// replace folder path if present in script
+
+	interpolated = strings.ReplaceAll(interpolated, "$PathToAtomicsFolder", flagAtomicsPath)
+	interpolated = strings.ReplaceAll(interpolated, "PathToAtomicsFolder", flagAtomicsPath)
+
+	if len(args) == 0 {
+		return interpolated
+	}
+
+	if gVerbose {
+		fmt.Println("\nInterpolating command with input arguments...")
+	}
+
+	for k, v := range args {
+		if gVerbose {
+			fmt.Printf("  - interpolating [#{%s}] => [%s]\n", k, v)
+		}
+		if !strings.HasPrefix(v, "http") { // No modification of slashes in case of URLs
+			if AtomicsFolderRegex.MatchString(v) {
+				v = AtomicsFolderRegex.ReplaceAllString(v, "")
+				v = strings.ReplaceAll(v, `\`, `/`)
+				v = strings.TrimSuffix(flagAtomicsPath, "/") + "/" + v
+			}
+
+			v = filepath.FromSlash(v)
+		}
+		interpolated = strings.ReplaceAll(interpolated, "#{"+k+"}", v)
+	}
+
+	return interpolated
+}
+
 func RunTests() {
 	numTestsRun := 0
 	testRuns := []*SingleTestRun{}
@@ -1050,8 +1195,19 @@ func RunTests() {
 
 			SaveState(testRuns)
 
-			if ShouldBeSkipped(rec) {
-				fmt.Println("Test Warning - skipping", testRun.criteria.Technique, testRun.criteria.TestName)
+			// load atomic to get default args
+			atomic,testIndex := LoadAtomic(rec.Technique, rec.TestIndex, rec.TestGuid, filepath.FromSlash(flagAtomicsPath), gVerbose)
+			if atomic != nil {
+				err = checkPlatform(atomic)
+				if err != nil {
+					fmt.Println("ERROR: Unable to find atomic test for ", rec)
+				} else {
+					FillArgDefaults(atomic, rec, filepath.FromSlash(flagAtomicsPath))
+				}
+			}
+
+			if atomic == nil || err != nil || ShouldBeSkipped(rec) {
+				fmt.Println("Test Warning - skipping", testRun.criteria.Technique, testRun.criteria.TestName, err)
 				fmt.Println("   " + testRun.criteria.Warnings[0])
 				MarkAsSkipped(testRun)
 				SaveState(testRuns)
@@ -1066,18 +1222,26 @@ func RunTests() {
 
 			testRun.workingDir = workingDir
 
-			// load atomic to get default args
-			utils.LoadAtomicDefaultArgs(rec, filepath.FromSlash(flagAtomicsPath), gVerbose)
-
 			// some test Args and field checks need variable substitutions
 
-			if false == SubstituteSysInfoArgs(rec) || false == SubstituteVarsInCriteria(testRun.criteria) {
+			if false == SubstituteSysInfoArgs(testRun.criteria) || false == SubstituteVarsInCriteria(testRun.criteria) {
 				MarkAsSkipped(testRun)
 				SaveState(testRuns)
 				continue
 			}
 
-			runConfig := BuildRunSpec(rec, workingDir, resultsDir)
+			args := consolidateArgs(atomic, testRun.criteria)
+
+			// test script and dependency scripts may need subsitution
+
+			atomic.Executor.Command = interpolateWithArgs(atomic.Executor.Command, atomic, args)
+			for i,_ := range atomic.Dependencies {
+				dep := &atomic.Dependencies[i]
+				dep.PrereqCommand = interpolateWithArgs(dep.PrereqCommand, atomic, args)
+				dep.GetPrereqCommand = interpolateWithArgs(dep.GetPrereqCommand, atomic, args)
+			}
+
+			runConfig := BuildRunSpec(atomic, testIndex, testRun.criteria, workingDir, resultsDir)
 			if runConfig == "" {
 				fmt.Println("empty runconfig!, skipping", rec)
 				continue
@@ -1300,6 +1464,12 @@ func Revalidate(prevResultsDir string) {
 	fmt.Println(SPrintState(testRuns, true))
 }
 
+/*
+ * Given a path to telemetry tool, returns suffix, if any.
+ * Examples:
+ *  telemtool          -> ""
+ *  telemtool_e2e.exe  -> "_e2e"
+ */
 func GetToolNameAndSuffixFromPath(path string) (string, string) {
 	retval := ""
 	_, name := filepath.Split(path)

--- a/cmd/harness/main.go
+++ b/cmd/harness/main.go
@@ -729,6 +729,8 @@ func BuildRunSpec(atomic *types.AtomicTest, TestIndex int, spec *types.AtomicTes
 	obj.ResultsDir, _ = filepath.Abs(filepath.FromSlash(resultsDir))
 	obj.Script = atomic.Executor
 	obj.Dependencies = atomic.Dependencies
+	obj.DependencyExecutorName = atomic.DependencyExecutorName
+
 	// TODO: environment variable overrides?
 	obj.Username = flagRegularRunUser
 	obj.Timeout = flagTimeout

--- a/cmd/harness/main_test.go
+++ b/cmd/harness/main_test.go
@@ -14,5 +14,5 @@ func TestTelemTools(t *testing.T) {
 	assert.Equal(t, "telemtool", tools[0].Name)
 	assert.Equal(t, "", tools[0].Suffix)
 	assert.Equal(t, "telemtool_e2e.exe", tools[1].Name)
-	assert.Equal(t, "e2e", tools[1].Suffix)
+	assert.Equal(t, "_e2e", tools[1].Suffix)
 }

--- a/pkg/types/atomic-schema.go
+++ b/pkg/types/atomic-schema.go
@@ -25,17 +25,6 @@ type AtomicTest struct {
 
 	Dependencies []Dependency    `yaml:"dependencies,omitempty"`
 	Executor     *AtomicExecutor `yaml:"executor"`
-
-	// from here down are not part of schema, used for state
-
-	BaseDir string `yaml:"-"`
-	TempDir string `yaml:"tempdir"`
-
-	Status      int               `yaml:"test_status,omitempty"`
-	IsCleanedUp bool              `yaml:"is_cleaned_up,omitempty"`
-	ArgsUsed    map[string]string `yaml:"args_used,omitempty"`
-	StartTime   int64
-	EndTime     int64
 }
 
 type InputArgument struct {
@@ -57,6 +46,4 @@ type AtomicExecutor struct {
 	Command           string `yaml:"command,omitempty"`
 	Steps             string `yaml:"steps,omitempty"`
 	CleanupCommand    string `yaml:"cleanup_command,omitempty"`
-
-	ExecutedCommand map[string]interface{} `yaml:"executed_command,omitempty"`
 }

--- a/pkg/types/runspec.go
+++ b/pkg/types/runspec.go
@@ -6,22 +6,35 @@ import (
 
 // RunSpec - schema for goartrun job
 type RunSpec struct {
-	Technique string
-	TestName  string
-	TestIndex int
-	TestGuid  string
+	ID         string
+	Label      string
 
-	AtomicsDir string
 	TempDir    string
 	ResultsDir string
 	Username   string
 
-	Inputs map[string]string
-	//Envs       []string
+    EnvOverrides map[string]string
+    Script       *AtomicExecutor
+
+	DependencyExecutorName string
+	Dependencies []Dependency
 
 	Stage   string
 	Timeout int64
 }
+
+type ScriptResults struct {
+        Spec RunSpec
+
+        Status      int
+        IsCleanedUp bool
+        StartTime   int64
+        EndTime     int64
+
+        CommandStdout string
+        ErrorMsg      string
+}
+
 
 type TestState int
 

--- a/pkg/utils/atr_utils.go
+++ b/pkg/utils/atr_utils.go
@@ -7,6 +7,7 @@ package utils
 import (
 	"bytes"
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -48,7 +49,7 @@ func LoadAtomicsTechniqueYaml(tid string, atomicsDir string) (*types.Atomic, err
 		return &technique, nil
 	}
 
-	return nil, fmt.Errorf("missing atomic", tid)
+	return nil, errors.New("missing atomic " + tid)
 }
 
 func GetPlatformName() string {

--- a/pkg/utils/datafile.go
+++ b/pkg/utils/datafile.go
@@ -7,6 +7,7 @@ package utils
 import (
 	"bytes"
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -47,7 +48,7 @@ func ParseFieldCriteria(str string, eventType string) (*types.FieldCriteria, err
 			// assume it's a path
 			a = []string{"path", str}
 		} else {
-			return nil, fmt.Errorf("no operator")
+			return nil, errors.New("no operator")
 		}
 	}
 	fc := &types.FieldCriteria{}
@@ -77,7 +78,7 @@ func ParseFieldCriteria(str string, eventType string) (*types.FieldCriteria, err
 
 func EventFromRow(id int, row []string) types.ExpectedEvent {
 	obj := types.ExpectedEvent{}
-	obj.Id = string(id)
+	obj.Id = fmt.Sprintf("%d",id)
 	obj.EventType = row[1] //strings.ToTitle(strings.ToLower(row[1]))
 	idx := 2
 	ET := strings.ToUpper(obj.EventType)


### PR DESCRIPTION
As detailed in the [cmd/goartrun/README.md](./cmd/goartrun/README.md) file, the runner is now a simplified script runner.  It does not need to fetch the atomic test, parse the yaml, do substitutions, etc.  All that is done in the harness now, which was already doing much of this work anyway.  This removes some duplicate work that was being done.  The struct definitions in [pkg/types/atomic-schema.go](./pkg/types/atomic-schema.go) have had the "state" fields removed, which should not have been there in the first place.

The `RunSpec` struct provided to `goartrun` by the harness has been changed to provide the processed (substitutions, etc) script (Executor) and dependencies needed to run.  The runner now serializes a `ScriptResults` struct to return to the harness.

More cleanup to do in a later MR, but this is a good step.
@kdebscwx @kchoudhury-scwx 